### PR TITLE
Require sessionid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "dotenv": "^16.4.5",
-        "ws": "^8.16.0"
+        "ws": "^8.17.0"
       },
       "devDependencies": {
         "nodemon": "^3.1.0"
@@ -410,9 +410,9 @@
       "dev": true
     },
     "node_modules/ws": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
-      "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.0.tgz",
+      "integrity": "sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -717,9 +717,9 @@
       "dev": true
     },
     "ws": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
-      "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.0.tgz",
+      "integrity": "sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==",
       "requires": {}
     },
     "yallist": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "homepage": "https://github.com/kokarn/tarkov-socket-server#readme",
   "dependencies": {
-    "ws": "^8.16.0",
+    "ws": "^8.17.0",
     "dotenv": "^16.4.5"
   },
   "devDependencies": {


### PR DESCRIPTION
Converts to requiring new method of authentication. Previously, websocket clients would establish the connection, and then subsequently send a "connect" message providing the sessionId. Under the new method, clients provide the sessionId upon establishing the connection. When the sessionId isn't provided upon establishing the connection, it's possible to immediately terminate the connection without having to wait some period of time for the "connect" message.

The socket server currently allows clients to connect using both the "new" and "old" methods. This PR switches to only allowing the new method.

The website and Tarkov Monitor have been transitioned over to using the new method of authentication, so this should be safe to deploy now.